### PR TITLE
nginx gateway setup

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -27,6 +27,16 @@ services:
       ACCEPT_EULA: "Y"
     volumes:
       - mssql_data:/var/opt/mssql
+      
+  nginx:
+    build:
+      context: ./gateway
+      dockerfile: Dockerfile
+    container_name: nginx_reverse_proxy
+    ports:
+      - "80:80"
+    depends_on:
+      - api
 
 volumes:
   mssql_data:

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,0 +1,8 @@
+FROM nginx:latest
+
+# This is the media for NGINX to serve static and uploaded files
+VOLUME /etc/nginx/multimedia
+
+# Copy the main configuration
+COPY prod.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/nginx.conf

--- a/gateway/nginx.conf
+++ b/gateway/nginx.conf
@@ -1,0 +1,26 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    client_max_body_size 100M;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    keepalive_timeout  65;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/gateway/prod.conf
+++ b/gateway/prod.conf
@@ -1,0 +1,25 @@
+server {
+    listen 80 default_server;
+
+    server_name adventour_api;
+
+    proxy_set_header   Host $host;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header   X-Forwarded-Host $server_name;
+
+    location / {
+        proxy_pass http://api:8080;  # Forward requests to the .NET API
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection keep-alive;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
What You Just Did
You set up Nginx as a reverse proxy for your .NET API running in a Docker container. This allows Nginx to handle incoming traffic and forward it to your API, while also preparing it for production deployment. Let’s break it down step by step.

1. You Added Nginx to Your Docker Compose Setup
Before, your setup only had:

api (your .NET application)
db (your MSSQL database)
Now, you've added an nginx service in docker-compose.yml. This means:

Nginx will act as a front-facing server that receives HTTP requests.
It will forward those requests to api (your .NET backend).
Your API no longer needs to expose ports to the outside world—only Nginx is exposed.
Key Docker Changes
The nginx service is now built from a Dockerfile inside gateway/.
Your API is no longer exposed to the host directly; instead, it communicates internally with Nginx.
You mapped config files into Nginx (nginx.conf and prod.conf).
2. You Created a Custom Nginx Docker Image
Inside gateway/Dockerfile, you defined how to build an Nginx container that:

Uses the official nginx:latest image.
Copies two configuration files (nginx.conf and prod.conf).
Defines a volume for media files (/etc/nginx/multimedia).
This ensures Nginx has custom behavior for your API instead of using default settings.

3. You Configured Nginx as a Reverse Proxy
The main job of Nginx here is to forward requests to your .NET API.

What Happens in prod.conf?
nginx
Copiar código
location / {
    proxy_pass http://api:8080;
}
Any request to http://localhost will be redirected to your .NET API (api:8080).
The api name is used because Docker Compose automatically assigns internal hostnames based on service names.
Other Key Settings
proxy_set_header ensures correct forwarding of request headers.
proxy_http_version 1.1; ensures keep-alive connections for better performance.
error_page 500 502 503 504 defines a custom error page for failures.
4. How Everything Works Together
A user visits http://localhost in their browser.
Nginx receives the request because it's listening on port 80.
Nginx forwards the request to api:8080, which is your .NET backend.
The .NET API processes the request and returns a response.
Nginx sends the response back to the client.
Why Use Nginx?
✅ Security – The API is not exposed directly to the internet.
✅ Scalability – You can later add rate limiting, caching, or load balancing.
✅ Flexibility – Nginx can serve static files, route requests, and compress responses.

5. Running Your Setup
You built and ran the new setup using:

sh
Copiar código
docker-compose up --build
--build ensures that Docker rebuilds the Nginx image with the new config files.
Now, visiting http://localhost routes to your .NET API through Nginx.